### PR TITLE
Add async experimentation

### DIFF
--- a/crawler_async.py
+++ b/crawler_async.py
@@ -1,0 +1,68 @@
+from src.company_item import CompanyItem
+from src.scrape_ashbyhq import ScrapeAshbyhqAsync
+import time
+from caqui import synchronous
+import asyncio
+
+MAX_CONCURRENCY = 5  # number of WebDriver instances
+sem = asyncio.Semaphore(MAX_CONCURRENCY)
+
+async def __schedule_tasks(companies):
+    tasks = [asyncio.ensure_future(__collect_data(company)) for company in companies]
+    await asyncio.gather(*tasks)
+
+
+async def __collect_data(company):
+    async with sem:
+        driver_url = "http://127.0.0.1:9999"
+        capabilities = {
+            "desiredCapabilities": {
+                "name": "webdriver",
+                "browserName": "firefox",
+                "marionette": True,
+                "acceptInsecureCerts": True,
+                # uncomment to set headless
+                "goog:chromeOptions": {"extensions": [], "args": ["--headless"]},
+            }
+        }
+        session = synchronous.get_session(driver_url, capabilities)
+        driver = [driver_url, session]
+
+        data = await company.scraper_type().getJobs(driver, company.jobs_url, company.company_name)
+        for entry in data:
+            print(entry)
+
+        synchronous.close_session(*driver)
+
+    
+async def __schedule_tasks():
+    companies = [
+        CompanyItem('kiln', 'https://jobs.ashbyhq.com/kiln.fi', ScrapeAshbyhqAsync, 'https://www.kiln.fi', 'Staking'),
+        CompanyItem('dune', 'https://jobs.ashbyhq.com/dune', ScrapeAshbyhqAsync, 'https://dune.com',
+                    'Web3 data'),
+        CompanyItem('conduit', 'https://jobs.ashbyhq.com/Conduit', ScrapeAshbyhqAsync, 'https://conduit.xyz',
+                    'Infrastructure'),
+        CompanyItem('paradigm.xyz', 'https://jobs.ashbyhq.com/paradigm', ScrapeAshbyhqAsync, 'https://www.paradigm.xyz',
+                    'Web3 data'),
+        CompanyItem('syndica', 'https://jobs.ashbyhq.com/syndica', ScrapeAshbyhqAsync, 'https://www.sygnum.com',
+                    'Crypto bank'),
+        CompanyItem('solana-foundation', 'https://jobs.ashbyhq.com/Solana%20Foundation', ScrapeAshbyhqAsync,
+                    'https://www.sygnum.com',
+                    'Crypto bank'),
+        CompanyItem('ellipsislabs', 'https://jobs.ashbyhq.com/ellipsislabs', ScrapeAshbyhqAsync,
+                    'https://ellipsislabs.xyz', 'Trading Protocol')
+    ]
+    tasks = [asyncio.ensure_future(__collect_data(company)) for company in companies]
+    await asyncio.gather(*tasks)
+
+
+if __name__ == "__main__":
+    start = time.time()
+    loop = asyncio.get_event_loop()
+    try:
+        loop.run_until_complete(__schedule_tasks())
+    finally:
+        loop.run_until_complete(loop.shutdown_asyncgens())
+        loop.close()
+        end = time.time()
+        print(f"Time: {end-start:.2f} sec")

--- a/crawler_async.py
+++ b/crawler_async.py
@@ -1,11 +1,13 @@
 from src.company_item import CompanyItem
 from src.scrape_ashbyhq import ScrapeAshbyhqAsync
+from src.scrape_lever import ScrapeLeverAsync
 import time
 from caqui import synchronous
 import asyncio
 
 MAX_CONCURRENCY = 5  # number of WebDriver instances
 sem = asyncio.Semaphore(MAX_CONCURRENCY)
+
 
 async def __schedule_tasks(companies):
     tasks = [asyncio.ensure_future(__collect_data(company)) for company in companies]
@@ -14,7 +16,7 @@ async def __schedule_tasks(companies):
 
 async def __collect_data(company):
     async with sem:
-        driver_url = "http://127.0.0.1:9999"
+        driver_url = "http://127.0.0.1:9515"
         capabilities = {
             "desiredCapabilities": {
                 "name": "webdriver",
@@ -34,7 +36,7 @@ async def __collect_data(company):
 
         synchronous.close_session(*driver)
 
-    
+
 async def __schedule_tasks():
     companies = [
         CompanyItem('kiln', 'https://jobs.ashbyhq.com/kiln.fi', ScrapeAshbyhqAsync, 'https://www.kiln.fi', 'Staking'),
@@ -50,7 +52,13 @@ async def __schedule_tasks():
                     'https://www.sygnum.com',
                     'Crypto bank'),
         CompanyItem('ellipsislabs', 'https://jobs.ashbyhq.com/ellipsislabs', ScrapeAshbyhqAsync,
-                    'https://ellipsislabs.xyz', 'Trading Protocol')
+                    'https://ellipsislabs.xyz', 'Trading Protocol'),
+        CompanyItem('bebop', 'https://jobs.lever.co/Bebop', ScrapeLeverAsync, 'https://bebop.xyz', 'DeFi Exchange'),
+        CompanyItem("kraken", "https://jobs.lever.co/kraken", ScrapeLeverAsync, "https://kraken.com", "Exchange"),
+        CompanyItem('arbitrumfoundation', 'https://jobs.lever.co/arbitrumfoundation', ScrapeLeverAsync,
+                    'https://arbitrum.foundation', 'Layer 2'),
+        CompanyItem("chainlink", "https://jobs.lever.co/chainlink", ScrapeLeverAsync, "https://chain.link",
+                    "Blockchain"),
     ]
     tasks = [asyncio.ensure_future(__collect_data(company)) for company in companies]
     await asyncio.gather(*tasks)
@@ -65,4 +73,4 @@ if __name__ == "__main__":
         loop.run_until_complete(loop.shutdown_asyncgens())
         loop.close()
         end = time.time()
-        print(f"Time: {end-start:.2f} sec")
+        print(f"Time: {end - start:.2f} sec")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ jsonschema==3.2.0
 selenium==4.8.0
 urllib3==1.26.13
 userpath==1.8.0
+pytest
+pytest-asyncio
+caqui

--- a/src/scrape_ashbyhq.py
+++ b/src/scrape_ashbyhq.py
@@ -4,10 +4,12 @@ from caqui import synchronous, asynchronous
 
 CSS_SELECTOR = "css"  # for ChromeDriver
 
+
 def clean_location(location):
     locations = list(filter(None, ([x.strip() for x in location.split('•')])))
     result = locations[1]
     return result.strip().title()
+
 
 class ScrapeAshbyhqAsync(ScrapeIt):
     name = 'ashbyhq'

--- a/src/scrape_ashbyhq.py
+++ b/src/scrape_ashbyhq.py
@@ -1,11 +1,52 @@
 from selenium.webdriver.common.by import By
 from src.scrape_it import ScrapeIt, write_jobs
+from caqui import synchronous, asynchronous
 
+CSS_SELECTOR = "css"  # for ChromeDriver
 
 def clean_location(location):
     locations = list(filter(None, ([x.strip() for x in location.split('•')])))
     result = locations[1]
     return result.strip().title()
+
+class ScrapeAshbyhqAsync(ScrapeIt):
+    name = 'ashbyhq'
+
+    async def getJobs(self, driver, web_page, company) -> []:
+        print(f'[{self.name}] Scrap page: {web_page}')
+        # driver.get(web_page)
+        await asynchronous.go_to_page(*driver, web_page)
+        # driver.implicitly_wait(5)
+        await asynchronous.set_timeouts(*driver, 5000)
+        # group_elements = driver.find_elements(By.CSS_SELECTOR, 'a[class*="container_"]')
+        group_elements = await asynchronous.find_elements(*driver, CSS_SELECTOR, 'a[class*="container_"]')
+        job_location_locator = 'div p'
+        print(f'[{self.name}] Found {len(group_elements)} jobs on {web_page}')
+        result = []
+        for elem in group_elements:
+            link_elem = elem
+            # job_name_elem = elem.find_element(By.CSS_SELECTOR, 'h3')
+            job_name_elem = await asynchronous.find_child_element(*driver, elem, CSS_SELECTOR, "h3")
+            # location_elem = elem.find_element(By.CSS_SELECTOR, job_location_locator)
+            location_elem = await asynchronous.find_child_element(*driver, elem, CSS_SELECTOR, job_location_locator)
+            # job_url = link_elem.get_attribute('href')
+            job_url = await asynchronous.get_attribute(*driver, link_elem, "href")
+            # job_name = job_name_elem.text
+            job_name = await asynchronous.get_text(*driver, job_name_elem)
+            # location = location_elem.text
+            location = await asynchronous.get_text(*driver, location_elem)
+            print("location", location)
+            cleaned_location = location.replace('\n', ', ')
+            job = {
+                "company": company,
+                "title": job_name,
+                "location": clean_location(cleaned_location),
+                "link": f"<a href='{job_url}' target='_blank' >Apply</a>"
+            }
+            result.append(job)
+        print(f'[{self.name}] Scraped {len(result)} jobs from {web_page}')
+        write_jobs(result)
+        return result
 
 
 class ScrapeAshbyhq(ScrapeIt):

--- a/src/scrape_ashbyhq.py
+++ b/src/scrape_ashbyhq.py
@@ -35,7 +35,6 @@ class ScrapeAshbyhqAsync(ScrapeIt):
             job_name = await asynchronous.get_text(*driver, job_name_elem)
             # location = location_elem.text
             location = await asynchronous.get_text(*driver, location_elem)
-            print("location", location)
             cleaned_location = location.replace('\n', ', ')
             job = {
                 "company": company,

--- a/src/scrape_lever.py
+++ b/src/scrape_lever.py
@@ -1,5 +1,8 @@
+from caqui import asynchronous
 from selenium.webdriver.common.by import By
 from src.scrape_it import ScrapeIt, write_jobs
+
+CSS_SELECTOR = "css"  # for ChromeDriver
 
 
 def clean_location(location):
@@ -36,6 +39,43 @@ class ScrapeLever(ScrapeIt):
             job = {
                 "company": company,
                 "title": link_elem.text,
+                "location": clean_location(merge_location),
+                "link": f"<a href='{job_url}' target='_blank' >Apply</a>"
+            }
+            result.append(job)
+        print(f'[LEVER] Scraped {len(result)} jobs from {web_page}')
+        write_jobs(result)
+        return result
+
+
+class ScrapeLeverAsync(ScrapeIt):
+    name = 'Lever'
+
+    async def getJobs(self, driver, web_page, company) -> []:
+        print(f'[{self.name}] Scrap page: {web_page}')
+        await asynchronous.go_to_page(*driver, web_page)
+        await asynchronous.set_timeouts(*driver, 5000)
+        group_elements = await asynchronous.find_elements(*driver, CSS_SELECTOR, 'a[class="posting-title"]')
+        print(f'[LEVER] Found {len(group_elements)} jobs.')
+        result = []
+        for elem in group_elements:
+            link_elem = await asynchronous.find_child_element(*driver, elem, CSS_SELECTOR, '[data-qa="posting-name"]')
+            location_elem = await asynchronous.find_children_elements(*driver, elem, CSS_SELECTOR, '[class*="location"]')
+            workplace_elem = await asynchronous.find_children_elements(*driver, elem, CSS_SELECTOR, '[class*="workplaceTypes"]')
+            job_url = await asynchronous.get_attribute(*driver, elem, "href")
+            title_text = await asynchronous.get_text(*driver, link_elem)
+            if len(location_elem) > 0:
+                location = await asynchronous.get_text(*driver, location_elem[0])
+            else:
+                location = ''
+            if len(workplace_elem) > 0:
+                workplace = await asynchronous.get_text(*driver, workplace_elem[0])
+                merge_location = f'{location},{workplace}'
+            else:
+                merge_location = location
+            job = {
+                "company": company,
+                "title": title_text,
                 "location": clean_location(merge_location),
                 "link": f"<a href='{job_url}' target='_blank' >Apply</a>"
             }

--- a/test/test_ashbyhq_scraper.py
+++ b/test/test_ashbyhq_scraper.py
@@ -2,6 +2,9 @@ from selenium import webdriver
 from src.company_item import CompanyItem
 from src.scrape_ashbyhq import ScrapeAshbyhq
 
+import time 
+start = time.time()
+
 options = webdriver.ChromeOptions()
 options.add_argument('--headless')
 driver = webdriver.Chrome(options=options)
@@ -28,3 +31,6 @@ for company in companies:
         print(entry)
 
 driver.close()
+
+end = time.time()
+print(f"Time: {end-start:.2f} sec")

--- a/test/test_ashbyhq_scraper_async.py
+++ b/test/test_ashbyhq_scraper_async.py
@@ -1,0 +1,53 @@
+from selenium import webdriver
+from src.company_item import CompanyItem
+from src.scrape_ashbyhq import ScrapeAshbyhqAsync
+import time
+from caqui import synchronous
+from pytest import mark
+
+@mark.asyncio
+async def test_ashbyhq_async():
+    start = time.time()
+    # options = webdriver.ChromeOptions()
+    # options.add_argument('--headless')
+    # driver = webdriver.Chrome(options=options)
+    driver_url = "http://127.0.0.1:9999"
+    capabilities = {
+        "desiredCapabilities": {
+            "name": "webdriver",
+            "browserName": "firefox",
+            "marionette": True,
+            "acceptInsecureCerts": True,
+            # uncomment to set headless
+            "goog:chromeOptions": {"extensions": [], "args": ["--headless"]},
+        }
+    }
+    session = synchronous.get_session(driver_url, capabilities)
+    driver = [driver_url, session]
+
+    companies = [
+        CompanyItem('kiln', 'https://jobs.ashbyhq.com/kiln.fi', ScrapeAshbyhqAsync, 'https://www.kiln.fi', 'Staking'),
+        CompanyItem('dune', 'https://jobs.ashbyhq.com/dune', ScrapeAshbyhqAsync, 'https://dune.com',
+                    'Web3 data'),
+        CompanyItem('conduit', 'https://jobs.ashbyhq.com/Conduit', ScrapeAshbyhqAsync, 'https://conduit.xyz',
+                    'Infrastructure'),
+        CompanyItem('paradigm.xyz', 'https://jobs.ashbyhq.com/paradigm', ScrapeAshbyhqAsync, 'https://www.paradigm.xyz',
+                    'Web3 data'),
+        CompanyItem('syndica', 'https://jobs.ashbyhq.com/syndica', ScrapeAshbyhqAsync, 'https://www.sygnum.com',
+                    'Crypto bank'),
+        CompanyItem('solana-foundation', 'https://jobs.ashbyhq.com/Solana%20Foundation', ScrapeAshbyhqAsync,
+                    'https://www.sygnum.com',
+                    'Crypto bank'),
+        CompanyItem('ellipsislabs', 'https://jobs.ashbyhq.com/ellipsislabs', ScrapeAshbyhqAsync,
+                    'https://ellipsislabs.xyz', 'Trading Protocol')
+    ]
+
+    for company in companies:
+        data = await company.scraper_type().getJobs(driver, company.jobs_url, company.company_name)
+        for entry in data:
+            print(entry)
+
+    synchronous.close_session(*driver)
+
+    end = time.time()
+    print(f"Time: {end-start:.2f} sec")


### PR DESCRIPTION
Hi, how are you? I'm using your code to test one library I've been working on. I did some experimentation using asynchronous calls to WebDreiver, and for company "ashbyhq" it was possible to reduce the execution time from **11.82 seconds to 8.55 sec.** I used 5 instances of ChromeDriver. I'm sending this PR just to show you an example of the implementation using this [library](https://github.com/douglasdcm/caqui). Feel free to ignore/reject it :)

If you want to test the PR, you have to start `chromedriver` as a server and run crawler like this
```
$ ./chromedriver --port=9999

Starting ChromeDriver 113.0.5672.63 (0e1a4471d5ae5bf128b1bd8f4d627c8cbd55f70c-refs/branch-heads/5672@{#912}) on port 9999
Only local connections are allowed.
Please see https://chromedriver.chromium.org/security-considerations for suggestions on keeping ChromeDriver safe.
ChromeDriver was started successfully.
``` 

run the crawler
```
$ python crawler_async.py 
ashbyhq] Scrap page: https://jobs.ashbyhq.com/kiln.fi
[ashbyhq] Scrap page: https://jobs.ashbyhq.com/dune
[ashbyhq] Scrap page: https://jobs.ashbyhq.com/Conduit
[ashbyhq] Scrap page: https://jobs.ashbyhq.com/paradigm
[ashbyhq] Scrap page: https://jobs.ashbyhq.com/syndica
[ashbyhq] Found 4 jobs on https://jobs.ashbyhq.com/Conduit
location Engineering • San Francisco, Remote • Full time
location Engineering • San Francisco, Remote • Full time
[ashbyhq] Found 11 jobs on https://jobs.ashbyhq.com/syndica
location Engineering • San Francisco, Remote • Full time
location Engineering • San Francisco, Remote • Full time
...

Time: 8.55 sec
```

Thank you!